### PR TITLE
feat(kno-2633): add support for trigger_data and other fixes

### DIFF
--- a/knock/client.go
+++ b/knock/client.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -135,7 +135,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, v interface{}) ([]by
 // the response.  This is meant for internal testing and shouldn't be used
 // directly. Instead please use `Client.do`.
 func (c *Client) handleResponse(ctx context.Context, res *http.Response, v interface{}) ([]byte, error) {
-	out, err := ioutil.ReadAll(res.Body)
+	out, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/knock/objects.go
+++ b/knock/objects.go
@@ -2,6 +2,7 @@ package knock
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -86,13 +87,14 @@ type GetObjectMessagesRequest struct {
 	ObjectID   string `url:"-"`
 	Collection string `url:"-"`
 
-	PageSize  int                `url:"page_size,omitempty"`
-	Before    string             `url:"before,omitempty"`
-	After     string             `url:"after,omitempty"`
-	Source    string             `url:"source,omitempty"`
-	Tenant    string             `url:"tenant,omitempty"`
-	Status    []EngagementStatus `url:"status,omitempty"`
-	ChannelID string             `url:"channel_id,omitempty"`
+	PageSize    int                    `url:"page_size,omitempty"`
+	Before      string                 `url:"before,omitempty"`
+	After       string                 `url:"after,omitempty"`
+	Source      string                 `url:"source,omitempty"`
+	Tenant      string                 `url:"tenant,omitempty"`
+	Status      []EngagementStatus     `url:"status,omitempty"`
+	ChannelID   string                 `url:"channel_id,omitempty"`
+	TriggerData map[string]interface{} `url:"-"`
 }
 type GetObjectMessagesResponse struct {
 	Items    []*ObjectMessage `json:"entries"`
@@ -166,6 +168,17 @@ func (os *objectsService) GetMessages(ctx context.Context, getObjectMessagesRequ
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error parsing query parameters to list object messages")
 	}
+
+	if getObjectMessagesRequest.TriggerData != nil {
+		triggerDataJson, err := json.Marshal(getObjectMessagesRequest.TriggerData)
+
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "error converting TriggerData into JSON")
+		}
+
+		queryString.Add("trigger_data", string(triggerDataJson))
+	}
+
 	path := fmt.Sprintf("%s/messages?%s", objectAPIPath(getObjectMessagesRequest.Collection, getObjectMessagesRequest.ObjectID), queryString.Encode())
 
 	req, err := os.client.newRequest(http.MethodGet, path, nil)


### PR DESCRIPTION
Add support for the `trigger_data` param on the following endpoints:

* Messages list
* Message activities
* User messages
* Object messages
* User feed

And other fixes

