### PR TITLE
feat(kno-4306): add objects bulk endpoints support

### DIFF
--- a/knock/objects.go
+++ b/knock/objects.go
@@ -16,7 +16,9 @@ import (
 type ObjectsService interface {
 	Get(context.Context, *GetObjectRequest) (*Object, error)
 	Set(context.Context, *SetObjectRequest) (*Object, error)
+	BulkSet(context.Context, *BulkSetObjectsRequest) (*BulkOperation, error)
 	Delete(context.Context, *DeleteObjectRequest) error
+	BulkDelete(context.Context, *BulkDeleteObjectsRequest) (*BulkOperation, error)
 	List(context.Context, *ListObjectsRequest) ([]*Object, *PageInfo, error)
 
 	GetMessages(context.Context, *GetObjectMessagesRequest) ([]*ObjectMessage, *PageInfo, error)
@@ -31,6 +33,7 @@ type ObjectsService interface {
 	SetPreferences(context.Context, *SetObjectPreferencesRequest) (*PreferenceSet, error)
 
 	AddSubscriptions(context.Context, *AddSubscriptionsRequest) ([]*ObjectSubscription, error)
+	BulkAddSubscriptions(context.Context, *BulkAddSubscriptionsRequest) (*BulkOperation, error)
 	DeleteSubscriptions(context.Context, *DeleteSubscriptionsRequest) ([]*ObjectSubscription, error)
 	ListSubscriptions(context.Context, *ListSubscriptionsRequest) (*ListSubscriptionsResponse, error)
 }
@@ -86,6 +89,17 @@ type SetObjectRequest struct {
 	Collection string                 `json:"-"`
 	Properties map[string]interface{} `json:""`
 }
+
+type BulkSetObject struct {
+	ID         string `json:"id"`
+	Properties map[string]interface{}
+}
+
+type BulkSetObjectsRequest struct {
+	Collection string           `json:"-"`
+	Objects    []*BulkSetObject `json:"objects"`
+}
+
 type ListObjectsRequest struct {
 	Collection string `url:"-"`
 	ObjectId   string `url:"object_id,omitempty"`
@@ -98,6 +112,11 @@ type ListObjectsRequest struct {
 type SetObjectResponse = GetObjectResponse
 
 type DeleteObjectRequest = GetObjectRequest
+
+type BulkDeleteObjectsRequest struct {
+	Collection string   `json:"-"`
+	ObjectIDs  []string `json:"object_ids"`
+}
 
 type ListObjectsResponse struct {
 	Entries  []*Object `json:"entries"`
@@ -211,6 +230,17 @@ type AddSubscriptionsResponse struct {
 	Subscriptions []*ObjectSubscription
 }
 
+type BulkAddObjectSubscription struct {
+	ID         string                 `json:"id"`
+	Properties map[string]interface{} `json:"properties,omitempty"`
+	Recipients []interface{}          `json:"recipients"`
+}
+
+type BulkAddSubscriptionsRequest struct {
+	Collection    string                       `json:"-"`
+	Subscriptions []*BulkAddObjectSubscription `json:"subscriptions"`
+}
+
 type DeleteSubscriptionsRequest struct {
 	ObjectID   string        `json:"-"`
 	Collection string        `json:"-"`
@@ -232,6 +262,10 @@ type ListSubscriptionsRequest struct {
 type ListSubscriptionsResponse struct {
 	Entries  []*ObjectSubscription `json:"entries"`
 	PageInfo *PageInfo             `json:"page_info"`
+}
+
+type BulkRequestResponse struct {
+	BulkOperation *BulkOperation
 }
 
 func collectionAPIPath(collection string) string {
@@ -356,6 +390,28 @@ func (os *objectsService) Set(ctx context.Context, setObjectRequest *SetObjectRe
 	return setObjectResponse.Object, nil
 }
 
+func (os *objectsService) BulkSet(ctx context.Context, bulkSetObjectsRequest *BulkSetObjectsRequest) (*BulkOperation, error) {
+	path := fmt.Sprintf("%s/bulk/set", collectionAPIPath(bulkSetObjectsRequest.Collection))
+
+	req, err := os.client.newRequest(http.MethodPost, path, bulkSetObjectsRequest, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating request to bulk set objects")
+	}
+
+	bulkSetObjectsRes := BulkRequestResponse{BulkOperation: &BulkOperation{}}
+
+	_, err = os.client.do(ctx, req, bulkSetObjectsRes.BulkOperation)
+	if err != nil {
+		return nil, errors.Wrap(err, "error making request to bulk set objects")
+	}
+
+	if err != nil {
+		return nil, errors.Wrap(err, "error parsing request to bulk set objects")
+	}
+
+	return bulkSetObjectsRes.BulkOperation, nil
+}
+
 func (os *objectsService) Delete(ctx context.Context, deleteObjectRequest *DeleteObjectRequest) error {
 	path := objectAPIPath(deleteObjectRequest.Collection, deleteObjectRequest.ID)
 
@@ -370,6 +426,28 @@ func (os *objectsService) Delete(ctx context.Context, deleteObjectRequest *Delet
 	}
 
 	return nil
+}
+
+func (os *objectsService) BulkDelete(ctx context.Context, bulkDeleteObjectsRequest *BulkDeleteObjectsRequest) (*BulkOperation, error) {
+	path := fmt.Sprintf("%s/bulk/delete", collectionAPIPath(bulkDeleteObjectsRequest.Collection))
+
+	req, err := os.client.newRequest(http.MethodPost, path, bulkDeleteObjectsRequest, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating request to bulk delete objects")
+	}
+
+	bulkDeleteObjectsRes := BulkRequestResponse{BulkOperation: &BulkOperation{}}
+
+	_, err = os.client.do(ctx, req, bulkDeleteObjectsRes.BulkOperation)
+	if err != nil {
+		return nil, errors.Wrap(err, "error making request to bulk delete objects")
+	}
+
+	if err != nil {
+		return nil, errors.Wrap(err, "error parsing request to bulk delete objects")
+	}
+
+	return bulkDeleteObjectsRes.BulkOperation, nil
 }
 
 func (os *objectsService) List(ctx context.Context, listObjectsRequest *ListObjectsRequest) ([]*Object, *PageInfo, error) {
@@ -546,6 +624,28 @@ func (os *objectsService) AddSubscriptions(ctx context.Context, addSubscriptions
 	}
 
 	return addSubscriptionsResponse.Subscriptions, nil
+}
+
+func (os *objectsService) BulkAddSubscriptions(ctx context.Context, bulkAddSubscriptionsRequest *BulkAddSubscriptionsRequest) (*BulkOperation, error) {
+	path := fmt.Sprintf("%s/bulk/subscriptions/add", collectionAPIPath(bulkAddSubscriptionsRequest.Collection))
+
+	req, err := os.client.newRequest(http.MethodPost, path, bulkAddSubscriptionsRequest, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating request to bulk add subscriptions")
+	}
+
+	bulkAddSubscriptionsRes := BulkRequestResponse{BulkOperation: &BulkOperation{}}
+
+	_, err = os.client.do(ctx, req, bulkAddSubscriptionsRes.BulkOperation)
+	if err != nil {
+		return nil, errors.Wrap(err, "error making request to bulk add subscriptions")
+	}
+
+	if err != nil {
+		return nil, errors.Wrap(err, "error parsing request to bulk add subscriptions")
+	}
+
+	return bulkAddSubscriptionsRes.BulkOperation, nil
 }
 
 func (os *objectsService) DeleteSubscriptions(ctx context.Context, deleteSubscriptionsReq *DeleteSubscriptionsRequest) ([]*ObjectSubscription, error) {

--- a/knock/objects.go
+++ b/knock/objects.go
@@ -405,10 +405,6 @@ func (os *objectsService) BulkSet(ctx context.Context, bulkSetObjectsRequest *Bu
 		return nil, errors.Wrap(err, "error making request to bulk set objects")
 	}
 
-	if err != nil {
-		return nil, errors.Wrap(err, "error parsing request to bulk set objects")
-	}
-
 	return bulkSetObjectsRes.BulkOperation, nil
 }
 
@@ -441,10 +437,6 @@ func (os *objectsService) BulkDelete(ctx context.Context, bulkDeleteObjectsReque
 	_, err = os.client.do(ctx, req, bulkDeleteObjectsRes.BulkOperation)
 	if err != nil {
 		return nil, errors.Wrap(err, "error making request to bulk delete objects")
-	}
-
-	if err != nil {
-		return nil, errors.Wrap(err, "error parsing request to bulk delete objects")
 	}
 
 	return bulkDeleteObjectsRes.BulkOperation, nil
@@ -488,10 +480,6 @@ func (os *objectsService) GetChannelData(ctx context.Context, getChannelDataReq 
 		return nil, errors.Wrap(err, "error making request to get object channel data")
 	}
 
-	if err != nil {
-		return nil, errors.Wrap(err, "error parsing request to get object channel data")
-	}
-
 	return channelDataResponse.ChannelData, nil
 }
 
@@ -509,10 +497,6 @@ func (os *objectsService) SetChannelData(ctx context.Context, getChannelDataReq 
 		return nil, errors.Wrap(err, "error making request to set object channel data")
 	}
 
-	if err != nil {
-		return nil, errors.Wrap(err, "error parsing request to set object channel data")
-	}
-
 	return channelDataResponse.ChannelData, nil
 }
 
@@ -527,10 +511,6 @@ func (os *objectsService) DeleteChannelData(ctx context.Context, deleteObjectCha
 	_, err = os.client.do(ctx, req, nil)
 	if err != nil {
 		return errors.Wrap(err, "error making request to delete object channel data")
-	}
-
-	if err != nil {
-		return errors.Wrap(err, "error parsing request to delete object channel data")
 	}
 
 	return nil
@@ -552,10 +532,6 @@ func (os *objectsService) GetPreferences(ctx context.Context, getObjectPreferenc
 	_, err = os.client.do(ctx, req, &getPreferenceResponse.Preferences)
 	if err != nil {
 		return nil, errors.Wrap(err, "error making request to get object preferences")
-	}
-
-	if err != nil {
-		return nil, errors.Wrap(err, "error parsing request to get object preferences")
 	}
 
 	return getPreferenceResponse.Preferences, nil
@@ -597,10 +573,6 @@ func (os *objectsService) SetPreferences(ctx context.Context, setObjectPreferenc
 		return nil, errors.Wrap(err, "error making request to set object preferences")
 	}
 
-	if err != nil {
-		return nil, errors.Wrap(err, "error parsing request to set object preferences")
-	}
-
 	return setPreferenceResponse.Preferences, nil
 }
 
@@ -617,10 +589,6 @@ func (os *objectsService) AddSubscriptions(ctx context.Context, addSubscriptions
 	_, err = os.client.do(ctx, req, &addSubscriptionsResponse.Subscriptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "error making request to add subscriptions")
-	}
-
-	if err != nil {
-		return nil, errors.Wrap(err, "error parsing request to add subscriptions")
 	}
 
 	return addSubscriptionsResponse.Subscriptions, nil
@@ -641,10 +609,6 @@ func (os *objectsService) BulkAddSubscriptions(ctx context.Context, bulkAddSubsc
 		return nil, errors.Wrap(err, "error making request to bulk add subscriptions")
 	}
 
-	if err != nil {
-		return nil, errors.Wrap(err, "error parsing request to bulk add subscriptions")
-	}
-
 	return bulkAddSubscriptionsRes.BulkOperation, nil
 }
 
@@ -661,10 +625,6 @@ func (os *objectsService) DeleteSubscriptions(ctx context.Context, deleteSubscri
 	_, err = os.client.do(ctx, req, &deleteSubscriptionsResponse.Subscriptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "error making request to delete subscriptions")
-	}
-
-	if err != nil {
-		return nil, errors.Wrap(err, "error parsing request to delete subscriptions")
 	}
 
 	return deleteSubscriptionsResponse.Subscriptions, nil

--- a/knock/objects_test.go
+++ b/knock/objects_test.go
@@ -45,6 +45,52 @@ func TestObjects_Set(t *testing.T) {
 	c.Assert(have, qt.DeepEquals, want)
 }
 
+func TestObjects_BulkSet(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		out := `{"__typename":"BulkOperation","completed_at":null,"estimated_total_rows":2,"failed_at":null,"id":"b19d032a-fc3b-4a54-9f54-369484527201","inserted_at":"2022-05-27T11:12:08.281201Z","name":"users.identify","processed_rows":0,"progress_path":"/v1/bulk_operations/b19d032a-fc3b-4a54-9f54-369484527201","started_at":null,"status":"queued","updated_at":"2022-05-27T11:12:08.286507Z"}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+
+	bulkSet, err := client.Objects.BulkSet(ctx, &BulkSetObjectsRequest{
+		Collection: "test-collection",
+		Objects: []*BulkSetObject{
+			{
+				ID: "cool-object-1",
+				Properties: map[string]interface{}{
+					"nice": "cool",
+				},
+			},
+			{
+				ID: "cool-object-2",
+				Properties: map[string]interface{}{
+					"nice": "cool",
+				},
+			},
+		},
+	})
+
+	want := &BulkOperation{
+		ID:                 "b19d032a-fc3b-4a54-9f54-369484527201",
+		EstimatedTotalRows: 2,
+		ProgressPath:       "/v1/bulk_operations/b19d032a-fc3b-4a54-9f54-369484527201",
+		Status:             BulkOperationQueued,
+		InsertedAt:         ParseRFC3339Timestamp("2022-05-27T11:12:08.281201Z"),
+		UpdatedAt:          ParseRFC3339Timestamp("2022-05-27T11:12:08.286507Z"),
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(bulkSet, qt.DeepEquals, want)
+}
+
 func TestObjects_Get(t *testing.T) {
 	c := qt.New(t)
 
@@ -143,6 +189,39 @@ func TestObjects_Delete(t *testing.T) {
 	})
 
 	c.Assert(err, qt.IsNil)
+}
+
+func TestObjects_BulkDelete(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		out := `{"__typename":"BulkOperation","completed_at":null,"estimated_total_rows":2,"failed_at":null,"id":"b19d032a-fc3b-4a54-9f54-369484527201","inserted_at":"2022-05-27T11:12:08.281201Z","name":"users.identify","processed_rows":0,"progress_path":"/v1/bulk_operations/b19d032a-fc3b-4a54-9f54-369484527201","started_at":null,"status":"queued","updated_at":"2022-05-27T11:12:08.286507Z"}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+
+	bulkDelete, err := client.Objects.BulkDelete(ctx, &BulkDeleteObjectsRequest{
+		Collection: "test-collection",
+		ObjectIDs:  []string{"cool-object-1", "cool-object-2"},
+	})
+
+	want := &BulkOperation{
+		ID:                 "b19d032a-fc3b-4a54-9f54-369484527201",
+		EstimatedTotalRows: 2,
+		ProgressPath:       "/v1/bulk_operations/b19d032a-fc3b-4a54-9f54-369484527201",
+		Status:             BulkOperationQueued,
+		InsertedAt:         ParseRFC3339Timestamp("2022-05-27T11:12:08.281201Z"),
+		UpdatedAt:          ParseRFC3339Timestamp("2022-05-27T11:12:08.286507Z"),
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(bulkDelete, qt.DeepEquals, want)
 }
 
 func TestObjects_GetChannelData(t *testing.T) {
@@ -322,4 +401,52 @@ func TestObjects_SetPreferences(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(have, qt.DeepEquals, want)
+}
+
+func TestObjects_BulkAddSubscriptions(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		out := `{"__typename":"BulkOperation","completed_at":null,"estimated_total_rows":2,"failed_at":null,"id":"b19d032a-fc3b-4a54-9f54-369484527201","inserted_at":"2022-05-27T11:12:08.281201Z","name":"users.identify","processed_rows":0,"progress_path":"/v1/bulk_operations/b19d032a-fc3b-4a54-9f54-369484527201","started_at":null,"status":"queued","updated_at":"2022-05-27T11:12:08.286507Z"}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+
+	bulkAdd, err := client.Objects.BulkAddSubscriptions(ctx, &BulkAddSubscriptionsRequest{
+		Collection: "test-collection",
+		Subscriptions: []*BulkAddObjectSubscription{
+			{
+				ID: "cool-object-1",
+				Properties: map[string]interface{}{
+					"nice": "cool",
+				},
+				Recipients: []interface{}{"user-1", "user-2"},
+			},
+			{
+				ID: "cool-object-2",
+				Properties: map[string]interface{}{
+					"nice": "cool",
+				},
+				Recipients: []interface{}{"user-1", "user-2"},
+			},
+		},
+	})
+
+	want := &BulkOperation{
+		ID:                 "b19d032a-fc3b-4a54-9f54-369484527201",
+		EstimatedTotalRows: 2,
+		ProgressPath:       "/v1/bulk_operations/b19d032a-fc3b-4a54-9f54-369484527201",
+		Status:             BulkOperationQueued,
+		InsertedAt:         ParseRFC3339Timestamp("2022-05-27T11:12:08.281201Z"),
+		UpdatedAt:          ParseRFC3339Timestamp("2022-05-27T11:12:08.286507Z"),
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(bulkAdd, qt.DeepEquals, want)
 }


### PR DESCRIPTION
- Adds support for the new bulk add subscriptions API
- Backfills missing support for the existing bulk set + delete objects APIs