### PR TITLE
fix: Add fixes for Tenants List endpoint

### DIFF
--- a/knock/tenants.go
+++ b/knock/tenants.go
@@ -41,7 +41,6 @@ type Tenant struct {
 // Client structs
 type ListTenantsRequest struct {
 	PageSize int    `url:"page_size,omitempty"`
-	Cursor   string `url:"page_size,omitempty"`
 	Before   string `url:"before,omitempty"`
 	After    string `url:"after,omitempty"`
 	TenantID string `url:"tenant_id,omitempty"`
@@ -49,7 +48,7 @@ type ListTenantsRequest struct {
 }
 
 type ListTenantsResponse struct {
-	Items    []*Tenant `json:"items"`
+	Entries  []*Tenant `json:"entries"`
 	PageInfo *PageInfo `json:"page_info"`
 }
 
@@ -79,7 +78,7 @@ func (ts *tenantsService) List(ctx context.Context, listReq *ListTenantsRequest)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error parsing request to list tenants")
 	}
-	path := fmt.Sprintf("%s/%s", tenantsAPIBasePath, queryString.Encode())
+	path := fmt.Sprintf("%s/?%s", tenantsAPIBasePath, queryString.Encode())
 
 	req, err := ts.client.newRequest(http.MethodGet, path, listReq, nil)
 
@@ -94,7 +93,7 @@ func (ts *tenantsService) List(ctx context.Context, listReq *ListTenantsRequest)
 		return nil, nil, errors.Wrap(err, "error making request to list tenants")
 	}
 
-	return listRes.Items, listRes.PageInfo, nil
+	return listRes.Entries, listRes.PageInfo, nil
 }
 func (ts *tenantsService) Get(ctx context.Context, getTenantRequest *GetTenantRequest) (*Tenant, error) {
 	path := tenantAPIPath(getTenantRequest.ID)

--- a/knock/tenants_test.go
+++ b/knock/tenants_test.go
@@ -94,7 +94,7 @@ func TestTenants_List(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		out := `{"items":[{"__typename":"Tenant","properties":{"name":"cool-tenant-1","settings":{"branding":{"primary_color":"#FFFFFF"}}},"id":"tenant-id","updated_at":"2022-05-17T00:34:18.277163Z"}],"page_info":{"__typename":"PageInfo","after":"big-after","before":null,"page_size":1}}`
+		out := `{"entries":[{"__typename":"Tenant","properties":{"name":"cool-tenant-1","settings":{"branding":{"primary_color":"#FFFFFF"}}},"id":"tenant-id","updated_at":"2022-05-17T00:34:18.277163Z"}],"page_info":{"__typename":"PageInfo","after":"big-after","before":null,"page_size":1}}`
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 	}))


### PR DESCRIPTION
* The endpoint returns the list of tenants using the `entries` key instead of `items`.
* Endpoint path fixed to prepend `?` to querystring.
* `Cursor` is not a valid element for `ListTenantsRequest`, not used for pagination in this endpoint (`before` and `after` are used instead).