### PR TITLE
minor: map resource_missing to ErrNotFound

### DIFF
--- a/knock/client.go
+++ b/knock/client.go
@@ -183,7 +183,7 @@ func (c *Client) handleResponse(ctx context.Context, res *http.Response, v inter
 
 		var errCode ErrorCode
 		switch errorRes.Code {
-		case "not_found":
+		case "not_found", "resource_missing":
 			errCode = ErrNotFound
 		case "unauthorized":
 			errCode = ErrPermission


### PR DESCRIPTION
## Why?

Let's say, I'm requesting preferences of non-existing user. In this case I get the following response:
```json
{
    "code": "resource_missing",
    "message": "The resource you requested does not exist",
    "status": 404,
    "type": "api_error"
}
```

I assume it means "the resource is not found" and should be mapped on ErrNotFound.
Unfortunately, at this moment it is not mapped on any error code at all. So, i've just added the mapping.