### PR TITLE
fix: add missing ID key from FeedItem struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/whoAbhishekSah/knock-go
+module github.com/knocklabs/knock-go
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/knocklabs/knock-go
+module github.com/whoAbhishekSah/knock-go
 
 go 1.18
 

--- a/knock/users.go
+++ b/knock/users.go
@@ -72,6 +72,7 @@ type Feed struct {
 }
 
 type FeedItem struct {
+	ID              string                 `json:"id"`
 	Activities      []*MessageActivity     `json:"activities"`
 	Actors          []*User                `json:"actors"`
 	TotalActivities int                    `json:"total_activities"`

--- a/knock/users_test.go
+++ b/knock/users_test.go
@@ -387,6 +387,7 @@ func TestFeed_Get(t *testing.T) {
 				InsertedAt: ParseRFC3339Timestamp("2021-05-11T00:50:09.904531Z"),
 				UpdatedAt:  ParseRFC3339Timestamp("2021-05-13T02:45:28.559863Z"),
 				SeenAt:     ParseRFC3339Timestamp("2021-05-11T00:51:43.617550Z"),
+				ID:         "1sMtIsRvZtYf86aOfkM2PCpC6Xc",
 			},
 		},
 		FeedMetadata: &FeedMetadata{

--- a/knock/users_test.go
+++ b/knock/users_test.go
@@ -336,6 +336,7 @@ func TestFeed_Get(t *testing.T) {
 	want := &Feed{
 		FeedItems: []*FeedItem{
 			{
+				ID: "1sMtIsRvZtYf86aOfkM2PCpC6Xc",
 				Activities: []*MessageActivity{
 					{
 						ID: "activity-id",
@@ -387,7 +388,6 @@ func TestFeed_Get(t *testing.T) {
 				InsertedAt: ParseRFC3339Timestamp("2021-05-11T00:50:09.904531Z"),
 				UpdatedAt:  ParseRFC3339Timestamp("2021-05-13T02:45:28.559863Z"),
 				SeenAt:     ParseRFC3339Timestamp("2021-05-11T00:51:43.617550Z"),
-				ID:         "1sMtIsRvZtYf86aOfkM2PCpC6Xc",
 			},
 		},
 		FeedMetadata: &FeedMetadata{


### PR DESCRIPTION
# Description

This PR adds the missing "ID" key from the FeedItem struct. 

# Test Plan

I've updated the unit test and done local dev testing with a test knock app to verify that the ID appears as expected in the JSON response of GetFeed API For users.