### PR TITLE
fix(kno-5952): improve readme trigger docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ workflow, _ := client.Workflows.Trigger(ctx, req, nil)
 fmt.Printf("workflow: %+v\n", workflow)
 ```
 
-Trigger for multiple recipients and and object
+Trigger for multiple recipients and an object
 
 ```go
 req := &knock.TriggerWorkflowRequest{

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ fmt.Printf("user-name: %+v\n", user)
 
 ### Sending notifies (triggering workflows)
 
-Simple trigger for one recipient:
+Simple trigger for one recipient by id:
 
 ```go
 req := &knock.TriggerWorkflowRequest{
@@ -68,6 +68,25 @@ req := &knock.TriggerWorkflowRequest{
     },
 }
 req.AddRecipientByID("tim")
+workflow, _ := client.Workflows.Trigger(ctx, req, nil)
+fmt.Printf("workflow: %+v\n", workflow)
+```
+
+Trigger with inline-identified recipient:
+
+```go
+req := &knock.TriggerWorkflowRequest{
+    Workflow:   "test",
+    Data: map[string]interface{}{
+        "life":      "found a way",
+        "dinosaurs": "loose",
+    },
+}
+req.AddRecipientByEntity(map[string]interface{}{
+    "id":    "dnedry",
+    "name":  "Dennis",
+    "email": "nedry@ingen.io",
+})
 workflow, _ := client.Workflows.Trigger(ctx, req, nil)
 fmt.Printf("workflow: %+v\n", workflow)
 ```

--- a/README.md
+++ b/README.md
@@ -57,14 +57,56 @@ fmt.Printf("user-name: %+v\n", user)
 
 ### Sending notifies (triggering workflows)
 
+Simple trigger for one recipient:
+
 ```go
-workflow, _ := client.Workflows.Trigger(ctx, &knock.TriggerWorkflowRequest{
+req := &knock.TriggerWorkflowRequest{
     Workflow:   "test",
-    Recipients: []string{"tim", "lex"},
     Data: map[string]interface{}{
         "life":      "found a way",
         "dinosaurs": "loose",
     },
+}
+req.AddRecipientByID("tim")
+workflow, _ := client.Workflows.Trigger(ctx, req, nil)
+fmt.Printf("workflow: %+v\n", workflow)
+```
+
+Trigger for multiple recipients and and object
+
+```go
+req := &knock.TriggerWorkflowRequest{
+    Workflow:   "test",
+    Data: map[string]interface{}{
+        "life":      "found a way",
+        "dinosaurs": "loose",
+    },
+}
+
+for _, r := range []string{"tim", "hammond"} {
+    req.AddRecipientByID(r)
+}
+
+req.AddRecipientByEntity(map[string]interface{}{
+    "id": "group-a",
+    "collection": "groups",
+})
+workflow, _ := client.Workflows.Trigger(ctx, req, nil)
+fmt.Printf("workflow: %+v\n", workflow)
+```
+
+Trigger with idempotency key
+```go
+req := &knock.TriggerWorkflowRequest{
+    Workflow:   "test",
+    Data: map[string]interface{}{
+        "life":      "found a way",
+        "dinosaurs": "loose",
+    },
+}
+req.AddRecipientByID("tim")
+workflow, _ := client.Workflows.Trigger(ctx, req, &knock.MethodOptions{
+    IdempotencyKey: "an-idempotency-key",
 })
 fmt.Printf("workflow: %+v\n", workflow)
 ```


### PR DESCRIPTION
This PR improves the workflow trigger section of the readme.
- fixes a bug where `client.Workflows.Trigger` was documented as having 2 args rather than 3
- replaces incorrect `Recipients: []string{"tim", "lex"}` example (wrong type) with multiple scenarios for using the `AddRecipient*` builders
- provides an example for triggering with an idempotency key

I've tested these new examples in a simple mock app.