### PR TITLE
chore: set knock user agent

### DIFF
--- a/knock/client.go
+++ b/knock/client.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 
 	"github.com/hashicorp/go-cleanhttp"
+	"github.com/knocklabs/knock-go/knock/internal"
 )
 
 const (
@@ -122,6 +124,8 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 // do makes an HTTP request and populates the given struct v from the response.
 func (c *Client) do(ctx context.Context, req *http.Request, v interface{}) ([]byte, error) {
 	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", fmt.Sprintf("knocklabs/go@%s", internal.SDKVersion))
+
 	res, err := c.client.Do(req)
 	if err != nil {
 		return nil, err

--- a/knock/internal/sdk_version.go
+++ b/knock/internal/sdk_version.go
@@ -1,5 +1,5 @@
 package internal
 
-// This is used for formatting the SDK's user agent. It should be updated before
+// SDKVersion is used to populate the sdk's user agent. It should be updated before
 // releasing new versions of the SDK. Eventually we can automate this process.
 const SDKVersion = "0.1.16"

--- a/knock/internal/sdk_version.go
+++ b/knock/internal/sdk_version.go
@@ -1,0 +1,5 @@
+package internal
+
+// This is used for formatting the SDK's user agent. It should be updated before
+// releasing new versions of the SDK. Eventually we can automate this process.
+const SDKVersion = "0.1.16"


### PR DESCRIPTION
This PR overrides the default go http client's user agent with a knock specific one.

We'll have to update `sdk_version.go` during our release process, but we already do that for other SDKs (e.g. elixir).

Here's an example log for a request I made with this branch:
![CleanShot 2024-05-22 at 10 36 59@2x](https://github.com/knocklabs/knock-go/assets/1269308/38b8b7bb-f709-42b0-9247-0acbb3232be9)

This is most likely the scheme we'll standardize around for all SDKs in the future.

