### PR TITLE
chore: prepare for 0.1.17 release

### DIFF
--- a/knock/client.go
+++ b/knock/client.go
@@ -124,7 +124,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 // do makes an HTTP request and populates the given struct v from the response.
 func (c *Client) do(ctx context.Context, req *http.Request, v interface{}) ([]byte, error) {
 	req = req.WithContext(ctx)
-	req.Header.Set("User-Agent", fmt.Sprintf("knocklabs/go@%s", internal.SDKVersion))
+	req.Header.Set("User-Agent", fmt.Sprintf("Knock/Go v%s", internal.SDKVersion))
 
 	res, err := c.client.Do(req)
 	if err != nil {

--- a/knock/internal/sdk_version.go
+++ b/knock/internal/sdk_version.go
@@ -2,4 +2,4 @@ package internal
 
 // SDKVersion is used to populate the sdk's user agent. It should be updated before
 // releasing new versions of the SDK. Eventually we can automate this process.
-const SDKVersion = "0.1.16"
+const SDKVersion = "0.1.17"


### PR DESCRIPTION
This PR fixes a bug in [this prev PR](https://github.com/knocklabs/knock-go/pull/34). We'd decided to change the user agent format to `Knock/Go vX.Y.Z` and I'd made that change but neglected to push it to the branch 🤦.

In addition to pushing the change this PR bumps `SDKVersion` to `0.1.17`. Once this PR is merged I'm going to cut a new release.