### PR TITLE
If content-type explicitly something other than json don't try to parse body as json

### DIFF
--- a/knock/client.go
+++ b/knock/client.go
@@ -151,9 +151,10 @@ func (c *Client) handleResponse(ctx context.Context, res *http.Response, v inter
 			Message string `json:"message"`
 		}
 
-		if res.Header.Get("Content-Type") != "" && res.Header.Get("Content-Type") != jsonMediaType {
+		// in some scenarios we don't fully control the response, e.g. an ELB 502.
+		if res.Header.Get("Content-Type") != jsonMediaType {
 			return nil, &Error{
-				msg:  "malformed non-json error response body received with status code " + http.StatusText(res.StatusCode),
+				msg:  "malformed non-json error response body received with status code: " + http.StatusText(res.StatusCode),
 				Code: ErrResponseMalformed,
 				Meta: map[string]string{
 					"body":        string(out),
@@ -168,7 +169,7 @@ func (c *Client) handleResponse(ctx context.Context, res *http.Response, v inter
 			var jsonErr *json.SyntaxError
 			if errors.As(err, &jsonErr) {
 				return nil, &Error{
-					msg:  "malformed error response body received with status code " + http.StatusText(res.StatusCode),
+					msg:  "malformed error response body received",
 					Code: ErrResponseMalformed,
 					Meta: map[string]string{
 						"body":        string(out),

--- a/knock/client_test.go
+++ b/knock/client_test.go
@@ -1,0 +1,122 @@
+package knock
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNewClient(t *testing.T) {
+	t.Run("default client", func(t *testing.T) {
+		client, err := NewClient()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if client == nil {
+			t.Fatal("Expected non-nil client")
+		}
+		if client.baseURL.String() != DefaultBaseUrl {
+			t.Errorf("Expected base URL %s, got %s", DefaultBaseUrl, client.baseURL.String())
+		}
+	})
+
+	t.Run("with custom base URL", func(t *testing.T) {
+		customURL := "https://custom.knock.app/"
+		client, err := NewClient(WithBaseURL(customURL))
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if client == nil {
+			t.Fatal("Expected non-nil client")
+		}
+		if client.baseURL.String() != customURL {
+			t.Errorf("Expected base URL %s, got %s", customURL, client.baseURL.String())
+		}
+	})
+}
+
+func TestClientDo(t *testing.T) {
+	t.Run("successful request", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !strings.Contains(r.Header.Get("User-Agent"), "Knock/Go v") {
+				t.Errorf("Expected User-Agent to contain 'Knock/Go v', got %s", r.Header.Get("User-Agent"))
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"message": "success"})
+		}))
+		defer server.Close()
+
+		client, _ := NewClient(WithBaseURL(server.URL))
+		req, _ := client.newRequest("GET", "/test", nil, nil)
+
+		var response map[string]string
+		_, err := client.do(context.Background(), req, &response)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if response["message"] != "success" {
+			t.Errorf("Expected message 'success', got %s", response["message"])
+		}
+	})
+
+	t.Run("error response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]string{"code": "not_found", "message": "Resource not found"})
+		}))
+		defer server.Close()
+
+		client, _ := NewClient(WithBaseURL(server.URL))
+		req, _ := client.newRequest("GET", "/test", nil, nil)
+
+		_, err := client.do(context.Background(), req, nil)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		knockErr, ok := err.(*Error)
+		if !ok {
+			t.Fatalf("Expected error of type *Error, got %T", err)
+		}
+		if knockErr.Code != ErrNotFound {
+			t.Errorf("Expected error code %v, got %v", ErrNotFound, knockErr.Code)
+		}
+		if knockErr.Error() != "Resource not found" {
+			t.Errorf("Expected error message 'Resource not found', got %s", knockErr.Error())
+		}
+	})
+
+	t.Run("unexpected non-json response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			w.Write([]byte("502 Bad Gateway"))
+		}))
+		defer server.Close()
+
+		client, _ := NewClient(WithBaseURL(server.URL))
+		req, _ := client.newRequest("GET", "/test", nil, nil)
+
+		_, err := client.do(context.Background(), req, nil)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		knockErr, ok := err.(*Error)
+		if !ok {
+			t.Fatalf("Expected error of type *Error, got %T", err)
+		}
+		if knockErr.Code != ErrResponseMalformed {
+			t.Errorf("Expected error code %v, got %v", ErrNotFound, knockErr.Code)
+		}
+		if knockErr.Error() != "malformed non-json error response body received with status code: Bad Gateway" {
+			t.Errorf("Expected error message 'Resource not found', got %s", knockErr.Error())
+		}
+	})
+}

--- a/knock/client_test.go
+++ b/knock/client_test.go
@@ -47,7 +47,10 @@ func TestClientDo(t *testing.T) {
 
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]string{"message": "success"})
+			err := json.NewEncoder(w).Encode(map[string]string{"message": "success"})
+			if err != nil {
+				t.Fatalf("Error encoding httptest response: %v", err)
+			}
 		}))
 		defer server.Close()
 
@@ -69,7 +72,10 @@ func TestClientDo(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusNotFound)
-			json.NewEncoder(w).Encode(map[string]string{"code": "not_found", "message": "Resource not found"})
+			err := json.NewEncoder(w).Encode(map[string]string{"code": "not_found", "message": "Resource not found"})
+			if err != nil {
+				t.Fatalf("Error encoding httptest response: %v", err)
+			}
 		}))
 		defer server.Close()
 
@@ -96,7 +102,10 @@ func TestClientDo(t *testing.T) {
 	t.Run("unexpected non-json response", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadGateway)
-			w.Write([]byte("502 Bad Gateway"))
+			_, err := w.Write([]byte("502 Bad Gateway"))
+			if err != nil {
+				t.Fatalf("Error writing httptest response: %v", err)
+			}
 		}))
 		defer server.Close()
 

--- a/knock/internal/sdk_version.go
+++ b/knock/internal/sdk_version.go
@@ -2,4 +2,4 @@ package internal
 
 // SDKVersion is used to populate the sdk's user agent. It should be updated before
 // releasing new versions of the SDK. Eventually we can automate this process.
-const SDKVersion = "0.1.17"
+const SDKVersion = "0.1.18"


### PR DESCRIPTION
We've periodically seen an issue where we get `malformed error response body received` errors from the knock client, which look like they're triggered by Bad Gateway's that returning a non-json response (probably html?). This sets it up so that *if* there is a content-type and its not explicitly application/json - the client does not try to parse the response as json. 

