### PR TITLE
fix: add additional BulkOperations fields, tests, and bump version to 0.1.20

### DIFF
--- a/knock/bulk_operation.go
+++ b/knock/bulk_operation.go
@@ -38,6 +38,10 @@ const (
 	Failed              BulkOperationStatus = "failed"
 )
 
+// ErrorItem represents an error that occurred during a bulk operation.
+// Error items have a dynamic schema that varies based on the operation type,
+type ErrorItem map[string]interface{}
+
 type BulkOperation struct {
 	ID                 string              `json:"id"`
 	CompletedAt        time.Time           `json:"completed_at"`
@@ -49,6 +53,10 @@ type BulkOperation struct {
 	ProcessedRows      int                 `json:"processed_rows"`
 	ProgressPath       string              `json:"progress_path"`
 	Status             BulkOperationStatus `json:"status"`
+	Name               string              `json:"name"`
+	SuccessCount       int                 `json:"success_count"`
+	ErrorCount         int                 `json:"error_count"`
+	ErrorItems         []ErrorItem         `json:"error_items"`
 }
 
 // Client structs

--- a/knock/bulk_operation_test.go
+++ b/knock/bulk_operation_test.go
@@ -14,7 +14,7 @@ func TestBulkOperation_get(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		out := `{"__typename":"BulkOperation","completed_at":null,"estimated_total_rows":42,"failed_at":null,"id":"b4f6f61e-3634-4e80-af0d-9c83e9acc6f3","name":"bulk_op","processed_rows":0,"progress_path":"/v1/bulk_operations/b4f6f61e-3634-4e80-af0d-9c83e9acc6f3","started_at":null,"status":"queued","inserted_at":"2021-03-05T12:00:00Z","updated_at":"2021-03-05T12:00:00Z"}`
+		out := `{"__typename":"BulkOperation","completed_at":null,"estimated_total_rows":42,"failed_at":null,"id":"b4f6f61e-3634-4e80-af0d-9c83e9acc6f3","name":"bulk_op","processed_rows":0,"progress_path":"/v1/bulk_operations/b4f6f61e-3634-4e80-af0d-9c83e9acc6f3","started_at":null,"status":"queued","inserted_at":"2021-03-05T12:00:00Z","updated_at":"2021-03-05T12:00:00Z","error_count":0,"success_count":0,"error_items":[]}`
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 	}))
@@ -35,6 +35,54 @@ func TestBulkOperation_get(t *testing.T) {
 		InsertedAt:         ParseRFC3339Timestamp("2021-03-05T12:00:00Z"),
 		UpdatedAt:          ParseRFC3339Timestamp("2021-03-05T12:00:00Z"),
 		EstimatedTotalRows: 42,
+		Name:               "bulk_op",
+		SuccessCount:       0,
+		ErrorCount:         0,
+		ErrorItems:         []ErrorItem{},
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(have, qt.DeepEquals, want)
+}
+
+func TestBulkOperation_get_with_error(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		out := `{"__typename":"BulkOperation","completed_at":null,"estimated_total_rows":5,"failed_at":null,"id":"b4f6f61e-3634-4e80-af0d-9c83e9acc6f3","name":"bulk_op","processed_rows":3,"progress_path":"/v1/bulk_operations/b4f6f61e-3634-4e80-af0d-9c83e9acc6f3","started_at":null,"status":"completed","inserted_at":"2021-03-05T12:00:00Z","updated_at":"2021-03-05T12:00:00Z","error_count":2,"success_count":1,"error_items":[{"id":"1"},{"id":"2"}]}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+
+	have, err := client.BulkOperations.Get(ctx, &GetBulkOperationRequest{
+		ID: "b4f6f61e-3634-4e80-af0d-9c83e9acc6f3",
+	})
+
+	want := &BulkOperation{
+		ID:                 "b4f6f61e-3634-4e80-af0d-9c83e9acc6f3",
+		ProgressPath:       "/v1/bulk_operations/b4f6f61e-3634-4e80-af0d-9c83e9acc6f3",
+		Status:             BulkOperationStatus(Completed),
+		InsertedAt:         ParseRFC3339Timestamp("2021-03-05T12:00:00Z"),
+		UpdatedAt:          ParseRFC3339Timestamp("2021-03-05T12:00:00Z"),
+		EstimatedTotalRows: 5,
+		ProcessedRows:      3,
+		Name:               "bulk_op",
+		SuccessCount:       1,
+		ErrorCount:         2,
+		ErrorItems: []ErrorItem{
+			map[string]interface{}{
+				"id": "1",
+			},
+			map[string]interface{}{
+				"id": "2",
+			},
+		},
 	}
 
 	c.Assert(err, qt.IsNil)

--- a/knock/internal/sdk_version.go
+++ b/knock/internal/sdk_version.go
@@ -2,4 +2,4 @@ package internal
 
 // SDKVersion is used to populate the sdk's user agent. It should be updated before
 // releasing new versions of the SDK. Eventually we can automate this process.
-const SDKVersion = "0.1.19"
+const SDKVersion = "0.1.20"

--- a/knock/messages_test.go
+++ b/knock/messages_test.go
@@ -498,7 +498,7 @@ func TestMessages_BulkChangeChannelStatus(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		out := `{"__typename":"BulkOperation","completed_at":null,"estimated_total_rows":1,"failed_at":null,"id":"fbf36d40-b6f8-4675-a362-ede1b859f757","inserted_at":"2022-05-28T00:51:26.343157Z","name":"messages.unread","processed_rows":0,"progress_path":"/v1/bulk_operations/fbf36d40-b6f8-4675-a362-ede1b859f757","started_at":null,"status":"queued","updated_at":"2022-05-28T00:51:26.349222Z"}`
+		out := `{"__typename":"BulkOperation","completed_at":null,"estimated_total_rows":1,"failed_at":null,"id":"fbf36d40-b6f8-4675-a362-ede1b859f757","inserted_at":"2022-05-28T00:51:26.343157Z","name":"messages.unread","processed_rows":0,"progress_path":"/v1/bulk_operations/fbf36d40-b6f8-4675-a362-ede1b859f757","started_at":null,"status":"queued","updated_at":"2022-05-28T00:51:26.349222Z","success_count":0,"error_count":0,"error_items":[]}`
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 	}))
@@ -524,6 +524,10 @@ func TestMessages_BulkChangeChannelStatus(t *testing.T) {
 		InsertedAt:         ParseRFC3339Timestamp("2022-05-28T00:51:26.343157Z"),
 		UpdatedAt:          ParseRFC3339Timestamp("2022-05-28T00:51:26.349222Z"),
 		EstimatedTotalRows: 1,
+		Name:               "messages.unread",
+		SuccessCount:       0,
+		ErrorCount:         0,
+		ErrorItems:         []ErrorItem{},
 	}
 
 	c.Assert(err, qt.IsNil)

--- a/knock/objects_test.go
+++ b/knock/objects_test.go
@@ -50,7 +50,7 @@ func TestObjects_BulkSet(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		out := `{"__typename":"BulkOperation","completed_at":null,"estimated_total_rows":2,"failed_at":null,"id":"b19d032a-fc3b-4a54-9f54-369484527201","inserted_at":"2022-05-27T11:12:08.281201Z","name":"users.identify","processed_rows":0,"progress_path":"/v1/bulk_operations/b19d032a-fc3b-4a54-9f54-369484527201","started_at":null,"status":"queued","updated_at":"2022-05-27T11:12:08.286507Z"}`
+		out := `{"__typename":"BulkOperation","completed_at":null,"estimated_total_rows":2,"failed_at":null,"id":"b19d032a-fc3b-4a54-9f54-369484527201","inserted_at":"2022-05-27T11:12:08.281201Z","name":"users.identify","processed_rows":0,"progress_path":"/v1/bulk_operations/b19d032a-fc3b-4a54-9f54-369484527201","started_at":null,"status":"queued","updated_at":"2022-05-27T11:12:08.286507Z","error_count":0,"success_count":0,"error_items":[]}`
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 	}))
@@ -85,6 +85,10 @@ func TestObjects_BulkSet(t *testing.T) {
 		Status:             BulkOperationQueued,
 		InsertedAt:         ParseRFC3339Timestamp("2022-05-27T11:12:08.281201Z"),
 		UpdatedAt:          ParseRFC3339Timestamp("2022-05-27T11:12:08.286507Z"),
+		Name:               "users.identify",
+		SuccessCount:       0,
+		ErrorCount:         0,
+		ErrorItems:         []ErrorItem{},
 	}
 
 	c.Assert(err, qt.IsNil)
@@ -196,7 +200,7 @@ func TestObjects_BulkDelete(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		out := `{"__typename":"BulkOperation","completed_at":null,"estimated_total_rows":2,"failed_at":null,"id":"b19d032a-fc3b-4a54-9f54-369484527201","inserted_at":"2022-05-27T11:12:08.281201Z","name":"users.identify","processed_rows":0,"progress_path":"/v1/bulk_operations/b19d032a-fc3b-4a54-9f54-369484527201","started_at":null,"status":"queued","updated_at":"2022-05-27T11:12:08.286507Z"}`
+		out := `{"__typename":"BulkOperation","completed_at":null,"estimated_total_rows":2,"failed_at":null,"id":"b19d032a-fc3b-4a54-9f54-369484527201","inserted_at":"2022-05-27T11:12:08.281201Z","name":"users.delete","processed_rows":0,"progress_path":"/v1/bulk_operations/b19d032a-fc3b-4a54-9f54-369484527201","started_at":null,"status":"queued","updated_at":"2022-05-27T11:12:08.286507Z","error_count":0,"success_count":0,"error_items":[]}`
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 	}))
@@ -218,6 +222,10 @@ func TestObjects_BulkDelete(t *testing.T) {
 		Status:             BulkOperationQueued,
 		InsertedAt:         ParseRFC3339Timestamp("2022-05-27T11:12:08.281201Z"),
 		UpdatedAt:          ParseRFC3339Timestamp("2022-05-27T11:12:08.286507Z"),
+		Name:               "users.delete",
+		SuccessCount:       0,
+		ErrorCount:         0,
+		ErrorItems:         []ErrorItem{},
 	}
 
 	c.Assert(err, qt.IsNil)
@@ -408,7 +416,7 @@ func TestObjects_BulkAddSubscriptions(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		out := `{"__typename":"BulkOperation","completed_at":null,"estimated_total_rows":2,"failed_at":null,"id":"b19d032a-fc3b-4a54-9f54-369484527201","inserted_at":"2022-05-27T11:12:08.281201Z","name":"users.identify","processed_rows":0,"progress_path":"/v1/bulk_operations/b19d032a-fc3b-4a54-9f54-369484527201","started_at":null,"status":"queued","updated_at":"2022-05-27T11:12:08.286507Z"}`
+		out := `{"__typename":"BulkOperation","completed_at":null,"estimated_total_rows":2,"failed_at":null,"id":"b19d032a-fc3b-4a54-9f54-369484527201","inserted_at":"2022-05-27T11:12:08.281201Z","name":"objects.test-collection.upsert_subscriptions","processed_rows":0,"progress_path":"/v1/bulk_operations/b19d032a-fc3b-4a54-9f54-369484527201","started_at":null,"status":"queued","updated_at":"2022-05-27T11:12:08.286507Z","error_count":0,"success_count":0,"error_items":[]}`
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 	}))
@@ -445,6 +453,10 @@ func TestObjects_BulkAddSubscriptions(t *testing.T) {
 		Status:             BulkOperationQueued,
 		InsertedAt:         ParseRFC3339Timestamp("2022-05-27T11:12:08.281201Z"),
 		UpdatedAt:          ParseRFC3339Timestamp("2022-05-27T11:12:08.286507Z"),
+		Name:               "objects.test-collection.upsert_subscriptions",
+		SuccessCount:       0,
+		ErrorCount:         0,
+		ErrorItems:         []ErrorItem{},
 	}
 
 	c.Assert(err, qt.IsNil)

--- a/knock/users_test.go
+++ b/knock/users_test.go
@@ -232,7 +232,7 @@ func TestUsers_BulkIdentify(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		out := `{"__typename":"BulkOperation","completed_at":null,"estimated_total_rows":2,"failed_at":null,"id":"b19d032a-fc3b-4a54-9f54-369484527201","inserted_at":"2022-05-27T11:12:08.281201Z","name":"users.identify","processed_rows":0,"progress_path":"/v1/bulk_operations/b19d032a-fc3b-4a54-9f54-369484527201","started_at":null,"status":"queued","updated_at":"2022-05-27T11:12:08.286507Z"}`
+		out := `{"__typename":"BulkOperation","completed_at":null,"estimated_total_rows":2,"failed_at":null,"id":"b19d032a-fc3b-4a54-9f54-369484527201","inserted_at":"2022-05-27T11:12:08.281201Z","name":"users.identify","processed_rows":0,"progress_path":"/v1/bulk_operations/b19d032a-fc3b-4a54-9f54-369484527201","started_at":null,"status":"queued","updated_at":"2022-05-27T11:12:08.286507Z","success_count":0,"error_count":0,"error_items":[]}`
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 	}))
@@ -274,6 +274,10 @@ func TestUsers_BulkIdentify(t *testing.T) {
 		Status:             BulkOperationQueued,
 		InsertedAt:         ParseRFC3339Timestamp("2022-05-27T11:12:08.281201Z"),
 		UpdatedAt:          ParseRFC3339Timestamp("2022-05-27T11:12:08.286507Z"),
+		Name:               "users.identify",
+		SuccessCount:       0,
+		ErrorCount:         0,
+		ErrorItems:         []ErrorItem{},
 	}
 
 	c.Assert(err, qt.IsNil)
@@ -285,7 +289,7 @@ func TestUsers_BulkDelete(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		out := `{"__typename":"BulkOperation","completed_at":null,"estimated_total_rows":2,"failed_at":null,"id":"0fb6a596-b579-455e-9a01-32b41fa5613a","inserted_at":"2022-05-27T11:26:50.869070Z","name":"users.delete","processed_rows":0,"progress_path":"/v1/bulk_operations/0fb6a596-b579-455e-9a01-32b41fa5613a","started_at":null,"status":"queued","updated_at":"2022-05-27T11:26:50.879642Z"}`
+		out := `{"__typename":"BulkOperation","completed_at":null,"estimated_total_rows":2,"failed_at":null,"id":"0fb6a596-b579-455e-9a01-32b41fa5613a","inserted_at":"2022-05-27T11:26:50.869070Z","name":"users.delete","processed_rows":0,"progress_path":"/v1/bulk_operations/0fb6a596-b579-455e-9a01-32b41fa5613a","started_at":null,"status":"queued","updated_at":"2022-05-27T11:26:50.879642Z","success_count":0,"error_count":0,"error_items":[]}`
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 	}))
@@ -307,6 +311,10 @@ func TestUsers_BulkDelete(t *testing.T) {
 		Status:             BulkOperationQueued,
 		InsertedAt:         ParseRFC3339Timestamp("2022-05-27T11:26:50.869070Z"),
 		UpdatedAt:          ParseRFC3339Timestamp("2022-05-27T11:26:50.879642Z"),
+		Name:               "users.delete",
+		SuccessCount:       0,
+		ErrorCount:         0,
+		ErrorItems:         []ErrorItem{},
 	}
 
 	c.Assert(err, qt.IsNil)
@@ -629,7 +637,7 @@ func TestUsers_BulkSetPreferences(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		out := `{"__typename":"BulkOperation","completed_at":null,"estimated_total_rows":3,"failed_at":null,"id":"1dcdaee8-9f22-4308-8d58-e6532f1501bd","inserted_at":"2022-06-08T12:37:34.367249Z","name":"users.set_preferences","processed_rows":0,"progress_path":"/v1/bulk_operations/1dcdaee8-9f22-4308-8d58-e6532f1501bd","started_at":null,"status":"queued","updated_at":"2022-06-08T12:37:34.374113Z"}`
+		out := `{"__typename":"BulkOperation","completed_at":null,"estimated_total_rows":3,"failed_at":null,"id":"1dcdaee8-9f22-4308-8d58-e6532f1501bd","inserted_at":"2022-06-08T12:37:34.367249Z","name":"users.set_preferences","processed_rows":0,"progress_path":"/v1/bulk_operations/1dcdaee8-9f22-4308-8d58-e6532f1501bd","started_at":null,"status":"queued","updated_at":"2022-06-08T12:37:34.374113Z","success_count":0,"error_count":0,"error_items":[]}`
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 	}))
@@ -666,6 +674,10 @@ func TestUsers_BulkSetPreferences(t *testing.T) {
 		ProgressPath:       "/v1/bulk_operations/1dcdaee8-9f22-4308-8d58-e6532f1501bd",
 		InsertedAt:         ParseRFC3339Timestamp("2022-06-08T12:37:34.367249Z"),
 		UpdatedAt:          ParseRFC3339Timestamp("2022-06-08T12:37:34.374113Z"),
+		Name:               "users.set_preferences",
+		SuccessCount:       0,
+		ErrorCount:         0,
+		ErrorItems:         []ErrorItem{},
 	}
 
 	c.Assert(err, qt.IsNil)


### PR DESCRIPTION
Adds the following fields to `BulkOperation`:
- `name`
- `success_count`
- `error_count`
- `error_items`

Bumps SDK to 0.1.20.

This is take 2 of https://github.com/knocklabs/knock-go/pull/40, with less Devin